### PR TITLE
Implement singleton logic

### DIFF
--- a/packages/sane/lib/src/exceptions.dart
+++ b/packages/sane/lib/src/exceptions.dart
@@ -186,3 +186,8 @@ final class SaneUnsupportedException extends SaneException {
   @override
   SANE_Status get _status => SANE_Status.STATUS_UNSUPPORTED;
 }
+
+/// SANE has been exited or the device has been closed.
+final class SaneDisposedError extends StateError {
+  SaneDisposedError() : super('SANE has been exited');
+}

--- a/packages/sane/lib/src/sane.dart
+++ b/packages/sane/lib/src/sane.dart
@@ -14,8 +14,13 @@ import 'package:sane/src/utils.dart';
 typedef AuthCallback = SaneCredentials Function(String resourceName);
 
 class Sane {
+  static Sane? _instance;
+  bool _exited = false;
   final Map<SaneHandle, SANE_Handle> _nativeHandles = {};
+
   SANE_Handle _getNativeHandle(SaneHandle handle) => _nativeHandles[handle]!;
+
+  Sane._();
 
   Future<int> init({
     AuthCallback? authCallback,
@@ -64,14 +69,20 @@ class Sane {
     return completer.future;
   }
 
+  factory Sane() => _instance ??= Sane._();
+
   Future<void> exit() {
     final completer = Completer<void>();
 
     Future(() {
+      _exited = true;
+
       dylib.sane_exit();
       print('sane_exit()');
 
       completer.complete();
+
+      _instance = null;
     });
 
     return completer.future;
@@ -80,6 +91,8 @@ class Sane {
   Future<List<SaneDevice>> getDevices({
     required bool localOnly,
   }) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<List<SaneDevice>>();
 
     Future(() {
@@ -108,6 +121,8 @@ class Sane {
   }
 
   Future<SaneHandle> open(String deviceName) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<SaneHandle>();
 
     Future(() {
@@ -133,10 +148,14 @@ class Sane {
   }
 
   Future<SaneHandle> openDevice(SaneDevice device) {
+    if (_exited) throw StateError('SANE has been exited');
+
     return open(device.name);
   }
 
   Future<void> close(SaneHandle handle) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<void>();
 
     Future(() {
@@ -154,6 +173,8 @@ class Sane {
     SaneHandle handle,
     int index,
   ) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<SaneOptionDescriptor>();
 
     Future(() {
@@ -175,6 +196,8 @@ class Sane {
   Future<List<SaneOptionDescriptor>> getAllOptionDescriptors(
     SaneHandle handle,
   ) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<List<SaneOptionDescriptor>>();
 
     Future(() {
@@ -201,6 +224,8 @@ class Sane {
     required SaneAction action,
     T? value,
   }) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<SaneOptionResult<T>>();
 
     Future(() {
@@ -393,6 +418,8 @@ class Sane {
   }
 
   Future<SaneParameters> getParameters(SaneHandle handle) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<SaneParameters>();
 
     Future(() {
@@ -416,6 +443,8 @@ class Sane {
   }
 
   Future<void> start(SaneHandle handle) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<void>();
 
     Future(() {
@@ -431,6 +460,8 @@ class Sane {
   }
 
   Future<Uint8List> read(SaneHandle handle, int bufferSize) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<Uint8List>();
 
     Future(() {
@@ -464,6 +495,8 @@ class Sane {
   }
 
   Future<void> cancel(SaneHandle handle) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<void>();
 
     Future(() {
@@ -477,6 +510,8 @@ class Sane {
   }
 
   Future<void> setIOMode(SaneHandle handle, SaneIOMode mode) {
+    if (_exited) throw StateError('SANE has been exited');
+
     final completer = Completer<void>();
 
     Future(() {

--- a/packages/sane/lib/src/sane.dart
+++ b/packages/sane/lib/src/sane.dart
@@ -91,7 +91,7 @@ class Sane {
   Future<List<SaneDevice>> getDevices({
     required bool localOnly,
   }) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<List<SaneDevice>>();
 
@@ -121,7 +121,7 @@ class Sane {
   }
 
   Future<SaneHandle> open(String deviceName) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<SaneHandle>();
 
@@ -148,13 +148,13 @@ class Sane {
   }
 
   Future<SaneHandle> openDevice(SaneDevice device) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     return open(device.name);
   }
 
   Future<void> close(SaneHandle handle) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<void>();
 
@@ -173,7 +173,7 @@ class Sane {
     SaneHandle handle,
     int index,
   ) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<SaneOptionDescriptor>();
 
@@ -196,7 +196,7 @@ class Sane {
   Future<List<SaneOptionDescriptor>> getAllOptionDescriptors(
     SaneHandle handle,
   ) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<List<SaneOptionDescriptor>>();
 
@@ -224,7 +224,7 @@ class Sane {
     required SaneAction action,
     T? value,
   }) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<SaneOptionResult<T>>();
 
@@ -418,7 +418,7 @@ class Sane {
   }
 
   Future<SaneParameters> getParameters(SaneHandle handle) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<SaneParameters>();
 
@@ -443,7 +443,7 @@ class Sane {
   }
 
   Future<void> start(SaneHandle handle) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<void>();
 
@@ -460,7 +460,7 @@ class Sane {
   }
 
   Future<Uint8List> read(SaneHandle handle, int bufferSize) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<Uint8List>();
 
@@ -495,7 +495,7 @@ class Sane {
   }
 
   Future<void> cancel(SaneHandle handle) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<void>();
 
@@ -510,7 +510,7 @@ class Sane {
   }
 
   Future<void> setIOMode(SaneHandle handle, SaneIOMode mode) {
-    if (_exited) throw StateError('SANE has been exited');
+    _checkIfExited();
 
     final completer = Completer<void>();
 
@@ -527,5 +527,10 @@ class Sane {
     });
 
     return completer.future;
+  }
+
+  @pragma('vm:prefer-inline')
+  void _checkIfExited() {
+    if (_exited) throw SaneDisposedError();
   }
 }

--- a/packages/sane/lib/src/sane.dart
+++ b/packages/sane/lib/src/sane.dart
@@ -14,13 +14,15 @@ import 'package:sane/src/utils.dart';
 typedef AuthCallback = SaneCredentials Function(String resourceName);
 
 class Sane {
+
+  factory Sane() => _instance ??= Sane._();
+
+  Sane._();
   static Sane? _instance;
   bool _exited = false;
   final Map<SaneHandle, SANE_Handle> _nativeHandles = {};
 
   SANE_Handle _getNativeHandle(SaneHandle handle) => _nativeHandles[handle]!;
-
-  Sane._();
 
   Future<int> init({
     AuthCallback? authCallback,
@@ -68,8 +70,6 @@ class Sane {
 
     return completer.future;
   }
-
-  factory Sane() => _instance ??= Sane._();
 
   Future<void> exit() {
     final completer = Completer<void>();

--- a/packages/sane/lib/src/sane.dart
+++ b/packages/sane/lib/src/sane.dart
@@ -14,10 +14,10 @@ import 'package:sane/src/utils.dart';
 typedef AuthCallback = SaneCredentials Function(String resourceName);
 
 class Sane {
-
   factory Sane() => _instance ??= Sane._();
 
   Sane._();
+
   static Sane? _instance;
   bool _exited = false;
   final Map<SaneHandle, SANE_Handle> _nativeHandles = {};

--- a/packages/sane/lib/src/sane.dart
+++ b/packages/sane/lib/src/sane.dart
@@ -27,6 +27,8 @@ class Sane {
   Future<int> init({
     AuthCallback? authCallback,
   }) {
+    _checkIfExited();
+
     final completer = Completer<int>();
 
     void authCallbackAdapter(
@@ -72,6 +74,8 @@ class Sane {
   }
 
   Future<void> exit() {
+    if (_exited) return Future.value();
+
     final completer = Completer<void>();
 
     Future(() {

--- a/packages/sane/test/sane_singleton_test.dart
+++ b/packages/sane/test/sane_singleton_test.dart
@@ -1,0 +1,33 @@
+import 'package:sane/sane.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Sane sane;
+
+  test('can instantiate', () {
+    sane = Sane();
+  });
+
+  test('same instance on repeated instantiation', () {
+    final newSane = Sane();
+    expect(sane, equals(newSane));
+  });
+
+  test('can exit', () {
+    expect(sane.exit, returnsNormally);
+  });
+
+  test('throws upon use', () {
+    expect(() => sane.getDevices(localOnly: true), throwsStateError);
+  });
+
+  test('can reinstiate with new instance', () {
+    final newSane = Sane();
+    expect(sane, isNot(newSane));
+    sane = newSane;
+  });
+
+  test('doesn\'t throw upon use', () {
+    expect(() => sane.getDevices(localOnly: true), returnsNormally);
+  });
+}

--- a/packages/sane/test/sane_singleton_test.dart
+++ b/packages/sane/test/sane_singleton_test.dart
@@ -18,7 +18,10 @@ void main() {
   });
 
   test('throws upon use', () {
-    expect(() => sane.getDevices(localOnly: true), throwsStateError);
+    expect(
+      () => sane.getDevices(localOnly: true),
+      throwsA(isA<SaneDisposedError>()),
+    );
   });
 
   test('can reinstiate with new instance', () {


### PR DESCRIPTION
Exiting marks the current global instance as disposed and removes the singleton, so the application can only ever have one valid and initiated instance.